### PR TITLE
Fix comparing position & incident line nums

### DIFF
--- a/src/shared/components/file-editor/file-editor.tsx
+++ b/src/shared/components/file-editor/file-editor.tsx
@@ -116,7 +116,7 @@ export const FileEditor: React.FC<IFileEditorProps> = ({
     return incidents.map((inc) => {
       return monaco.languages.registerHoverProvider("*", {
         provideHover: (model, position) => {
-          if (position.lineNumber !== inc.lineNumber) {
+          if (position.lineNumber !== absoluteToRelativeLineNum(inc.lineNumber)) {
             return undefined;
           }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed hover tooltips in the file editor so they align with the correct lines when viewing code snippets.
  * Hover details now map to the snippet’s line numbers rather than the full file, preventing mismatches.
  * Improves accuracy and trust in symbol info, links, and annotations while inspecting incident-related or partial code views.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->