### PR TITLE
:sparkles: Simplify multi-arch image build workflow

### DIFF
--- a/.github/workflows/multi-arch-image-build.yaml
+++ b/.github/workflows/multi-arch-image-build.yaml
@@ -23,31 +23,15 @@ jobs:
       registry: "quay.io/konveyor"
       image_name: "static-report"
       containerfile: "./Dockerfile"
-      architectures: '[ "amd64", "arm64", "ppc64le", "s390x" ]'
+      architectures: '[ "amd64", "arm64" ]'
       extra-args: "--build-arg VERSION=${{ github.ref_name }} --ulimit nofile=4096:4096"
     secrets:
       registry_username: ${{ secrets.QUAY_PUBLISH_ROBOT }}
       registry_password: ${{ secrets.QUAY_PUBLISH_TOKEN }}
-
-  windows-image-build:
-    runs-on: windows-latest
-    steps:
-    - uses: actions/checkout@main
-    - name: Login to Docker Hub
-      uses: docker/login-action@master
-      with:
-        registry: "quay.io/konveyor"
-        username: ${{ secrets.QUAY_PUBLISH_ROBOT }}
-        password: ${{ secrets.QUAY_PUBLISH_TOKEN }}
-    - name: Build static-report
-      run: |
-        docker build -f ./Dockerfile.windows -t quay.io/konveyor/static-report:$env:tag-windowsservercore-ltsc2022 .
-        docker push quay.io/konveyor/static-report:$env:tag-windowsservercore-ltsc2022
-
+      
   update-manifest:
     needs:
     - linux-image-build
-    - windows-image-build
     runs-on: ubuntu-latest
     steps:
     - name: update manifest


### PR DESCRIPTION
Removed Windows image build steps and updated supported architectures.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Simplified the build pipeline to focus on Linux architectures (amd64, arm64) only.
  * Removed support for ppc64le and s390x architectures.
  * Removed Windows build and deployment steps from the CI/CD workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->